### PR TITLE
Remove Composer conflict for Twig ^3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,8 +50,7 @@
         "webmozart/assert": "^1.9"
     },
     "conflict": {
-        "doctrine/orm": "2.15.2",
-        "twig/twig": "^3.0"
+        "doctrine/orm": "2.15.2"
     },
     "require-dev": {
         "hwi/oauth-bundle": "^1.1 || ^2.0@beta",


### PR DESCRIPTION
As a standalone bundle the SyliusUserBundle can be used with Twig 3.x, so please consider to remove the conflict in the composer.json. 